### PR TITLE
hash_table: add mapWithDataAndKey to allow void* to be passed to function argument

### DIFF
--- a/palm/include/palm/hash_table.h
+++ b/palm/include/palm/hash_table.h
@@ -8,8 +8,8 @@ typedef size_t (*hash_key_ft)(void *);
 typedef bool (*is_equal_ft)(void *, void *);
 typedef void *(*map_ft)(void *);
 typedef void *(*mapk_ft)(void *key, void *item);
+typedef void *(*mapdk_ft)(void *data, void *key, void *item);
 typedef void *(*fold_ft)(void *acc, void *item);
-
 
 htable_st *HTnew(size_t size, hash_key_ft hash_func, is_equal_ft is_equal_func);
 bool HTinsert(htable_st *table, void *key, void *value);
@@ -19,6 +19,7 @@ void HTclear(struct htable *table);
 void HTdelete(htable_st *table);
 void HTmap(htable_st *table, map_ft fun);
 void HTmapWithKey(htable_st *table, mapk_ft fun);
+void HTmapWithDataAndKey(htable_st *table, void *data, mapdk_ft fun);
 void HTfold(htable_st *table, fold_ft fun, void *init_acc);
 size_t HTelementCount(htable_st *table);
 

--- a/palm/src/hash_table.c
+++ b/palm/src/hash_table.c
@@ -201,7 +201,16 @@ void HTmapWithKey(struct htable *table, mapk_ft fun)
     }
 }
 
-
+void HTmapWithDataAndKey(htable_st *table, void *data, mapdk_ft fun)
+{
+    for (size_t i = 0; i < table->size; i++) {
+        struct htable_entry *entry = table->entries[i];
+        while (entry) {
+            entry->value = fun(data, entry->key, entry->value);
+            entry = entry->next;
+        }
+    }
+}
 
 
 


### PR DESCRIPTION
Hiermee heb je veel meer controle in de "lambda" functie zelf, omat ipv dat je ergens een globale variabele moet gebruiken je zelf een argument mee kan geven.