### PR TITLE
Make verbosity printing consistent

### DIFF
--- a/copra/src/phase_driver.c
+++ b/copra/src/phase_driver.c
@@ -99,7 +99,9 @@ struct ccn_node *CCNdispatchAction(struct ccn_action *action, enum ccn_nodetype 
         err(EXIT_FAILURE, "[coconut] error in phase driver.");
     }
     if (phase_driver.action_error) {
-        fprintf(stderr, "[coconut] Action error received. Stopping...\n");
+        if (phase_driver.verbosity > PD_V_QUIET) {
+            fprintf(stderr, "[coconut] Action error received. Stopping...\n");
+        }
         CTIabortCompilation();
     }
 
@@ -156,7 +158,9 @@ char *Checkbreakpoint(char *name)
     }
     if (phase_driver.breakpoint[len] == '.') {
         if (phase_driver.breakpoint[len + 1] == '\0') {
-            fprintf(stderr, "[coconut] breakpoint string is invalid.\n");
+            if (phase_driver.verbosity > PD_V_QUIET) {
+                fprintf(stderr, "[coconut] breakpoint string is invalid.\n");
+            }
             return NULL;
         }
         return phase_driver.breakpoint + len + 1;
@@ -205,7 +209,9 @@ struct ccn_node *StartPhase(struct ccn_phase *phase, char *phase_name, struct cc
     } while(cycle && phase_driver.cycle_iter < phase_driver.max_cycles && !(phase_driver.fixed_point));
 
     if (phase_driver.phase_error) {
-        fprintf(stderr, "[coconut] Phase error received. Stopping...\n");
+        if (phase_driver.verbosity > PD_V_QUIET) {
+            fprintf(stderr, "[coconut] Phase error received. Stopping...\n");
+        }
         CTIabortCompilation();
     }
 

--- a/copra/src/phase_driver.c
+++ b/copra/src/phase_driver.c
@@ -158,9 +158,7 @@ char *Checkbreakpoint(char *name)
     }
     if (phase_driver.breakpoint[len] == '.') {
         if (phase_driver.breakpoint[len + 1] == '\0') {
-            if (phase_driver.verbosity > PD_V_QUIET) {
-                fprintf(stderr, "[coconut] breakpoint string is invalid.\n");
-            }
+            fprintf(stderr, "[coconut] breakpoint string is invalid.\n");
             return NULL;
         }
         return phase_driver.breakpoint + len + 1;


### PR DESCRIPTION
In the phase_driver, `phase_driver.verbosity` is used to decide if certain information should be printed or not. Currently, this is not entirely consistent, as some prints are printed regardless of the verbosity level. To remedy this, I have added three if statements that check if the verbosity is set to something higher than `PD_V_QUIET`.
