### PR TITLE
Fix DBUG_ASSERT not replacing format args

### DIFF
--- a/palm/src/dbug.c
+++ b/palm/src/dbug.c
@@ -14,7 +14,9 @@ void DBUGprintAssert(int line, char *file, const char *func, char *msg, ...)
     va_start(arg_p, msg);
 
     fprintf(stderr, "ASSERTION FAILED: file %s, line %d in function: %s\n", file, line, func);
-    fprintf(stderr, "\t%s\n", msg);
+    fprintf(stderr, "\t");
+    vfprintf(stderr, msg, arg_p);
+    fprintf(stderr, "\n");
     fprintf(stderr, "ABORTING EXECUTION");
 
     va_end(arg_p);


### PR DESCRIPTION
Example:
```c
DBUG_ASSERT(false, "invalid node type %i", node_type);
```

Before:
```
ASSERTION FAILED: file /home/robin/git/ccn/src/trav/5_typechecker.c, line 173 in function: node_to_type
        invalid node type %i
```

After:
```
ASSERTION FAILED: file /home/robin/git/ccn/src/trav/5_typechecker.c, line 173 in function: node_to_type
        invalid node type 32
```