### PR TITLE
Properly initialize fp field

### DIFF
--- a/cocogen/generator/generator.c
+++ b/cocogen/generator/generator.c
@@ -23,6 +23,7 @@ GeneratorContext *GNnew()
     GeneratorContext *ctx = MEMmalloc(sizeof(GeneratorContext));
     ctx->indent_size = 4;
     ctx->indent_level = 0;
+    ctx->fp = NULL;
     return ctx;
 }
 


### PR DESCRIPTION
Currently the first call to `GNopenFile` tries to close an uninitialized file pointer.