### PR TITLE
Return existence of keys from HTinsert, add HTinsert_unique

### DIFF
--- a/palm/include/palm/hash_table.h
+++ b/palm/include/palm/hash_table.h
@@ -66,7 +66,8 @@ htable_st *HTdeep_copy(htable_st *table, cpy_ft key_copy_func,
 /**
  * Insert the key, value pair from the table.
  *
- * @return true if insertion was successful.
+ * @return true if the key was newly inserted, false if the key already existed
+ *         and its value was updated.
  */
 bool HTinsert(htable_st *table, void *key, void *value);
 

--- a/palm/include/palm/hash_table.h
+++ b/palm/include/palm/hash_table.h
@@ -72,6 +72,14 @@ htable_st *HTdeep_copy(htable_st *table, cpy_ft key_copy_func,
 bool HTinsert(htable_st *table, void *key, void *value);
 
 /**
+ * Try to insert the key, value pair from the table if the key does not exist
+ *
+ * @return true if the key was newly inserted, false if the key already existed,
+ *         in which case the table is unmodified
+ */
+bool HTinsert_unique(htable_st *table, void *key, void *value);
+
+/**
  * Lookup a value in the hash table.
  *
  * @return the corresponding value or NULL if key is not found.

--- a/palm/src/hash_table.c
+++ b/palm/src/hash_table.c
@@ -109,12 +109,12 @@ bool Insert(struct htable *table, void *key, void *value)
         for (; last->next; last = last->next) {
             if (table->is_equal_f(last->key, key)) {
                 last->value = value;
-                return true;
+                return false;
             }
         }
         if (table->is_equal_f(last->key, key)) {
             last->value = value;
-            return true;
+            return false;
         }
 
         target = &(last->next);

--- a/palm/src/hash_table.c
+++ b/palm/src/hash_table.c
@@ -96,7 +96,7 @@ void DeleteEntry(struct htable *table, struct htable_entry *entry)
 }
 
 static
-bool Insert(struct htable *table, void *key, void *value)
+bool Insert(struct htable *table, void *key, void *value, bool allow_overwrite)
 {
     struct htable_entry **target = NULL;
 
@@ -108,12 +108,16 @@ bool Insert(struct htable *table, void *key, void *value)
         struct htable_entry *last = table->entries[index];
         for (; last->next; last = last->next) {
             if (table->is_equal_f(last->key, key)) {
-                last->value = value;
+                if (allow_overwrite) {
+                    last->value = value;
+                }
                 return false;
             }
         }
         if (table->is_equal_f(last->key, key)) {
-            last->value = value;
+            if (allow_overwrite) {
+                last->value = value;
+            }
             return false;
         }
 
@@ -129,7 +133,12 @@ bool Insert(struct htable *table, void *key, void *value)
 
 bool HTinsert(struct htable *table, void *key, void *value)
 {
-    return Insert(table, key, value);
+    return Insert(table, key, value, true);
+}
+
+bool HTinsert_unique(struct htable *table, void *key, void *value)
+{
+    return Insert(table, key, value, false);
 }
 
 /**


### PR DESCRIPTION
Hi,

While writing my compiler, basically all of the cases in which I used a hash map were ones where I either
1) needed keys to be unique (e.g. scoping), or
2) wanted to use it as a kind of cache (i.e. take action first time I see the key, otherwise don't redo work)

As such, I personally found it useful to
1) have HTinsert report whether it created or modified an entry, but especially
2) have a HTinsert_unique (not stuck on the name) that would only create, and would report failure if the key existed.

I've therefore changed HTinsert (before it statically returned `true`, which isn't terribly useful information) and added HTinsert_unique in my code, and now also in this PR.

If you also think it's useful, feel free to use it.

Regards,
Peter