### PR TITLE
Avoid unused-include warnings by specifying IWYU pragmas

### DIFF
--- a/copra/ccn/ccn.h
+++ b/copra/ccn/ccn.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#include "ccn/phase_driver.h"
-#include "ccn/dynamic_core.h"
+#include "ccn/dynamic_core.h" // IWYU pragma: export
+#include "ccn/phase_driver.h" // IWYU pragma: export


### PR DESCRIPTION
This commit avoids the "Included header ccn.h is not used directly (fixes available)"  warning by clangd(unused-includes) in the following snippet. Adding the `export` pragma tells clangd that `ccn.h` intends to export the symbols as if they were its own.

See [here](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-export) for more information about the IWYU pragma, and [here](https://clangd.llvm.org/guides/include-cleaner) for more information about this clangd feature.

```c
#include "ccn/ccn.h"
#include "ccngen/ast.h"

node_st *FOOBARprogram(node_st *node)
{
    TRAVchildren(node);
    return node;
}
```