### PR TITLE
Save old fixed_point and cycle_iter to handle nested cycle & phase

### DIFF
--- a/copra/src/phase_driver.c
+++ b/copra/src/phase_driver.c
@@ -197,12 +197,19 @@ struct ccn_node *StartPhase(struct ccn_phase *phase, char *phase_name, struct cc
         phase_driver.action_id = curr_action_id;
         size_t action_counter = 0;
         enum ccn_action_id action_id = phase->action_table[action_counter];
+
+        size_t old_iter = phase_driver.cycle_iter;
+        bool old_fixed_point = phase_driver.fixed_point;
+        
         while (action_id != CCNAC_ID_NULL) {
+            old_fixed_point = phase_driver.fixed_point;
             struct ccn_action *action = CCNgetActionFromID(action_id);
             node = CCNdispatchAction(action, phase->root_type, node, false);
             action_counter++;
             action_id = phase->action_table[action_counter];
+            phase_driver.fixed_point = phase_driver.fixed_point && old_fixed_point;
         }
+        phase_driver.cycle_iter = old_iter;
         phase_driver.cycle_iter++;
     } while(cycle && phase_driver.cycle_iter < phase_driver.max_cycles && !(phase_driver.fixed_point));
 


### PR DESCRIPTION
In copra/src/phase_driver.c progress of a cycle is tracked using global variable phase_driver. When a cycle is nested with a phase or another cycle, the same global variable is used to track its progress and when that inner phase/cycle is over the state of the global phase_driver is not recovered, which can cause the outer cycle to exit even when CCNcycleNotify() is called during the outer cycle.

Minimum example:


```
start phase RootPhase {
    actions {
        looper;
    }
};

cycle looper {
    actions {

        pass cycleNotifier;

        phase CycleDestroyer {
            actions {
                pass do_nothing;
            }
        };
        
    }
};
```

```C
node_st *cycleNotifier(node_st *node) {
  CCNcycleNotify();
  return node;
}

node_st *do_nothing(node_st *node) {
  return node;
}
```
Result (using verbose mode):

```
>> RootPhase
>> looper
  *** cycleNotifier
>> CycleDestroyer
  *** do_nothing
<< CycleDestroyer
<< looper
<< RootPhase
```


I confirmed that by saving the old values of phase_driver variable before entering actions, this problem no longer exists.